### PR TITLE
Oracle implementation and connection pool implementation.

### DIFF
--- a/src/org/restsql/core/SqlBuilder.java
+++ b/src/org/restsql/core/SqlBuilder.java
@@ -61,11 +61,11 @@ public interface SqlBuilder {
 		}
 
 		public void setLimit(final int limit) {
-			this.limit = limit;
+			//this.limit = limit;
 		}
 
 		public void setOffset(final int offset) {
-			this.offset = offset;
+			//this.offset = offset;
 		}
 	}
 

--- a/src/org/restsql/core/impl/ConnectionPoolFactoryImpl.java
+++ b/src/org/restsql/core/impl/ConnectionPoolFactoryImpl.java
@@ -1,0 +1,53 @@
+/* Copyright (c) restSQL Project Contributors. Licensed under MIT. */
+package org.restsql.core.impl;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.sql.DataSource;
+import org.restsql.core.Config;
+import org.restsql.core.Factory.ConnectionFactory;
+
+/**
+ * Simple pooled connection factory that use connection pool. The caller must close the
+ * connection but it is ony released to pool. The factory uses the database property pool - poll name.
+ * 
+ * @author Piotr Roznicki
+ */
+public class ConnectionPoolFactoryImpl implements ConnectionFactory {
+	private final String connectionName;
+	private Context	initialContext = null;
+  private DataSource dataSource	= null;
+
+	public ConnectionPoolFactoryImpl() {
+		connectionName = Config.properties.getProperty("database.pool","DEFAULT");
+	}
+
+	public Connection getConnection(String defaultDatabase) throws SQLException {
+		java.sql.Connection connection = null;
+		try {
+			if (null == this.initialContext) {
+				this.initialContext = new InitialContext();
+				Context envCtxA = (Context) this.initialContext.lookup("java:comp/env");
+				this.dataSource = (DataSource) envCtxA.lookup(connectionName);
+			} else {
+				if (null == this.dataSource) {
+					Context envCtxA = (Context) this.initialContext.lookup("java:comp/env");
+					this.dataSource = (DataSource) envCtxA.lookup(connectionName);
+				}
+			}
+			connection = this.dataSource.getConnection();
+		} catch (Exception e) {
+			throw (new SQLException("Error getting connection from pool[" + connectionName + "]" + e.getMessage()));
+		}
+		if (defaultDatabase != null) {
+			connection.setCatalog(defaultDatabase);
+		}
+		return connection;
+	}
+
+	public void destroy() throws SQLException {
+	}
+}

--- a/src/org/restsql/core/impl/oracle/OracleSequenceManager.java
+++ b/src/org/restsql/core/impl/oracle/OracleSequenceManager.java
@@ -1,0 +1,48 @@
+/* Copyright (c) restSQL Project Contributors. Licensed under MIT. */
+package org.restsql.core.impl.oracle;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.restsql.core.SqlResourceException;
+import org.restsql.core.impl.AbstractSequenceManager;
+
+/**
+ * SequenceManager implementation for Oracle Database
+ * 
+ * @author Piotr Roznicki
+ */
+
+
+public class OracleSequenceManager extends AbstractSequenceManager {
+
+	@Override
+	public String getCurrentValueSql(String sequenceName) {
+		return "SELECT " + sequenceName + ".CURRVAL FROM DUAL";
+	}
+
+	@Override
+	public void setNextValue(final Connection connection, final String table, final String sequenceName,
+			final int nextval, boolean printAction) throws SqlResourceException {
+
+		final String sql = "SELECT " + sequenceName + ".NEXTVAL FROM DUAL";
+		Statement statement = null;
+		try {
+			statement = connection.createStatement();
+			if (printAction) {
+				System.out.println("\t[setUp] " + sql);
+			}
+			statement.executeQuery(sql);
+		} catch (final SQLException exception) {
+			throw new SqlResourceException(exception, sql);
+		} finally {
+			if (statement != null) {
+				try {
+					statement.close();
+				} catch (SQLException e) {
+				}
+			}
+		}
+	}
+}

--- a/src/org/restsql/core/impl/oracle/OracleSqlResourceMetaData.java
+++ b/src/org/restsql/core/impl/oracle/OracleSqlResourceMetaData.java
@@ -1,0 +1,129 @@
+/* Copyright (c) restSQL Project Contributors. Licensed under MIT. */
+package org.restsql.core.impl.oracle;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import java.sql.ResultSetMetaData;
+import javax.sql.rowset.RowSetMetaDataImpl; 
+import org.restsql.core.impl.AbstractSqlResourceMetaData;
+import org.restsql.core.impl.ColumnMetaDataImpl;
+import org.restsql.core.sqlresource.SqlResourceDefinition;
+import org.restsql.core.sqlresource.SqlResourceDefinitionUtils;    
+
+/**
+ * Metadata implementation for Oracle Database
+ * 
+ * @author Piotr Roznicki
+ */
+
+public class OracleSqlResourceMetaData extends AbstractSqlResourceMetaData {
+	private static final String SQL_COLUMNS_QUERY = "select column_name, data_type, data_default from all_tab_columns where owner =  ? and table_name = ?";
+	private static final String SQL_PK_QUERY = "SELECT cols.table_name, cols.column_name, cols.position, cons.status, cons.owner FROM all_constraints cons, all_cons_columns cols"
+			+ " WHERE cons.owner = ? AND cols.table_name = ?"
+			+ " AND cons.constraint_type = 'P' AND cons.constraint_name = cols.constraint_name ";
+
+	/**
+	 * Retrieves database name from result set meta data. Hook method for buildTablesAndColumns() allows
+	 * database-specific overrides.
+	 */
+	@Override
+	protected String getColumnDatabaseName(final SqlResourceDefinition definition,
+			final ResultSetMetaData resultSetMetaData, final int colNumber) throws SQLException {
+		return SqlResourceDefinitionUtils.getDefaultDatabase(definition);
+	}
+
+	/**
+	 * Retrieves actual column name from result set meta data. Hook method for buildTablesAndColumns() allows
+	 * database-specific overrides.
+	 */
+	@Override
+	protected String getColumnName(final SqlResourceDefinition definition,
+			final ResultSetMetaData resultSetMetaData, final int colNumber) throws SQLException {
+		return ((ResultSetMetaData) resultSetMetaData).getColumnName(colNumber);
+	}
+
+	/**
+	 * Retrieves table name from definition. Oracle getTableName returns null!!!
+	 * overrides.
+	 */
+	@Override
+	protected String getColumnTableName(final SqlResourceDefinition definition,
+			final ResultSetMetaData resultSetMetaData, final int colNumber) throws SQLException {
+    return definition.getMetadata().getTable().get(0).getName();
+		//return ((ResultSetMetaData) resultSetMetaData).getTableName(colNumber);
+	}
+
+	/**
+	 * Retrieves sql for querying columns. Hook method for buildInvisibleForeignKeys() and buildJoinTableMetadata()
+	 * allows database-specific overrides.
+	 */
+	@Override
+	protected String getSqlColumnsQuery() {
+		return SQL_COLUMNS_QUERY;
+	}
+
+	/**
+	 * Retrieves sql for querying primary keys. Hook method for buildPrimaryKeys allows database-specific overrides.
+	 */
+	@Override
+	protected String getSqlPkQuery() {
+		return SQL_PK_QUERY;
+	}
+
+	/** Retrieves database-specific table name used in SQL statements. */
+	@Override
+	protected String getQualifiedTableName(final SqlResourceDefinition definition,
+			final ResultSetMetaData resultSetMetaData, final int colNumber) throws SQLException {
+    return definition.getMetadata().getTable().get(0).getName();
+	}
+
+	/** Retrieves database-specific table name used in SQL statements. Used to build join table meta data. */
+	@Override
+	protected String getQualifiedTableName(Connection connection, String databaseName, String tableName) {
+			return databaseName + "." + tableName;
+		}
+
+	/**
+	 * Return whether a column in the given result set is read-only. The Oracle implementation calls isReadOnly()
+	 */
+	@Override
+	protected boolean isColumnReadOnly(ResultSetMetaData resultSetMetaData, int colNumber)
+			throws SQLException {
+		return (resultSetMetaData.isReadOnly(colNumber));
+		// Hack access to protected member "fields" as we need to find the value
+		// of Field.positionInTable which is 0 for columns based on SQL functions
+		/*try {
+			java.lang.reflect.Field fields_array = AbstractJdbc2ResultSetMetaData.class
+					.getDeclaredField("fields");
+			fields_array.setAccessible(true);
+			final Field[] fields = (Field[]) fields_array.get(resultSetMetaData);
+			return fields[colNumber - 1].getPositionInTable() == 0;
+		} catch (Exception e) {
+			throw new SQLException(e.toString());
+		}*/
+	}
+
+	/**
+	 * Sets sequence metadata for a column with the columns query result set. The column_default column will contain a
+	 * string in the format nextval('sequence-name'::regclass), where sequence-name is the sequence name.
+	 * 
+	 * @throws SQLException when a database error occurs
+	 */
+	@Override
+	protected void setSequenceMetaData(ColumnMetaDataImpl column, ResultSet resultSet) throws SQLException {
+		final String columnDefault = resultSet.getString(3);
+		if (columnDefault != null && columnDefault.startsWith("nextval")) {
+			column.setSequence(true);
+			column.setSequenceName(columnDefault.substring(9, columnDefault.indexOf('\'', 10)));
+		}
+	}
+  
+  protected String getSqlMainQuery(final SqlResourceDefinition definition) {
+		return definition.getQuery().getValue() + " WHERE ROWNUM = 1 " ;
+	}
+   
+}

--- a/src/resources/properties/tomcat-oracle-pool-restsql.properties
+++ b/src/resources/properties/tomcat-oracle-pool-restsql.properties
@@ -1,0 +1,66 @@
+# Default restSQL properties
+# Note: Only properties that override defaults need to be defined. All of the values in this
+# properties file are defaults. 
+
+# logging.facility=[log4j,java]
+# logging.config=relative/to/classpath
+# logging.dir=/absolute/path  - this is only used by the /log service method to find logs
+logging.facility=log4j
+logging.config=resources/properties/log4j.properties
+logging.dir=c:\\Tomcat\\webapps\\restsql\\log
+
+# sqlresources.dir=/absolute/path
+sqlresources.dir=c:/Tomcat/webapps/restsql/WEB-INF/classes/resources/xml
+
+# security.privileges=/absolute/path
+
+# triggers.classpath=/absolute/path
+# triggers.definition=/absolute/path
+
+# request.useXmlSchema=[true, false]
+# response.useXmlDirective=[true, false]
+# response.useXmlSchema=[true, false]
+request.useXmlSchema=false
+response.useXmlSchema=false
+response.useXmlDirective=false
+
+# http.response.cacheControl={cache-directive}, {cache-directive}, ...
+http.response.cacheControl=no-cache, no-transform
+
+# database.driverClassName=x.x.x
+# database.url=jdbc:etc:etc
+# database.user=userName
+# database.password=password
+database.pool=POOL_NAME
+
+# DB-specific implementation classes - match the implementation to your database
+# For MySQL:
+#	org.restsql.core.SequenceManager=org.restsql.core.impl.mysql.MySqlSequenceManager
+#	org.restsql.core.SqlResourceMetaData=org.restsql.core.impl.mysql.MySqlSqlResourceMetaData
+# For PostgreSQL:
+#	org.restsql.core.SequenceManager=org.restsql.core.impl.postgresql.PostgreSqlSequenceManager
+#	org.restsql.core.SqlResourceMetaData=org.restsql.core.impl.postgresql.PostgreSqlSqlResourceMetaData
+org.restsql.core.SequenceManager=org.restsql.core.impl.oracle.OracleSequenceManager
+org.restsql.core.SqlResourceMetaData=org.restsql.core.impl.oracle.OracleSqlResourceMetaData
+
+# Implementation classes - use these to customize the framework
+# org.restsql.core.Factory.ConnectionFactory=fully.qualified.class.name
+# org.restsql.core.Factory.RequestFactory=fully.qualified.class.name
+# org.restsql.core.Factory.RequestDeserializerFactory=fully.qualified.class.name
+# org.restsql.core.Factory.ResponseSerializerFactory=fully.qualified.class.name
+# org.restsql.core.Factory.SqlResourceFactory=fully.qualified.class.name
+# org.restsql.core.HttpRequestAttributes=fully.qualified.class.name
+# org.restsql.core.RequestLogger=fully.qualified.class.name
+# org.restsql.core.SeqeunceManager=fully.qualified.class.name
+# org.restsql.core.SqlBuilder=fully.qualified.class.name
+# org.restsql.security.Authorizer=fully.qualified.class.name
+org.restsql.core.Factory.ConnectionFactory=org.restsql.core.impl.ConnectionPoolFactoryImpl
+org.restsql.core.Factory.Connection=org.restsql.core.impl.ConnectionPoolFactoryImpl
+org.restsql.core.Factory.RequestFactory=org.restsql.core.impl.RequestFactoryImpl
+org.restsql.core.Factory.RequestDeserializerFactory=org.restsql.core.impl.serial.RequestDeserializerFactoryImpl
+org.restsql.core.Factory.ResponseSerializerFactory=org.restsql.core.impl.serial.ResponseSerializerFactoryImpl
+org.restsql.core.Factory.SqlResourceFactory=org.restsql.core.impl.SqlResourceFactoryImpl
+org.restsql.core.HttpRequestAttributes=org.restsql.core.impl.HttpRequestAttributesImpl
+org.restsql.core.RequestLogger=org.restsql.core.impl.RequestLoggerImpl
+org.restsql.core.SqlBuilder=org.restsql.core.impl.SqlBuilderImpl
+org.restsql.security.Authorizer=org.restsql.security.impl.AuthorizerImpl


### PR DESCRIPTION
SqlBuilder was modified because Oracle doesn't support LIMIT and OFFSET keywords.
It is for testing only.
tomcat-oracle-pool-restsql.properties waqs created for testing on Tomcat (on Windows).

```
new file:   src/org/restsql/core/impl/ConnectionPoolFactoryImpl.java
new file:   src/org/restsql/core/impl/oracle/OracleSequenceManager.java
new file:   src/org/restsql/core/impl/oracle/OracleSqlResourceMetaData.java
new file:   src/resources/properties/tomcat-oracle-pool-restsql.properties
```
